### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run dev"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Run on Repl.it](https://repl.it/badge/github/petebot/sapper-simple)](https://repl.it/github/petebot/sapper-simple)
+
+
 # sapper-template
 
 The default [Sapper](https://github.com/sveltejs/sapper) template, available for Rollup and webpack.


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).